### PR TITLE
Dirty hacks to get a cuda runtime working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ docker-run:
 	else \
 		echo "$(YELLOW)Running the app in Docker $(OPTIONS)...$(RESET)"; \
 		export WORKSPACE_BASE=${WORKSPACE_BASE}; \
-		export SANDBOX_USER_ID=$(shell id -u); \
+		#export SANDBOX_USER_ID=$(shell id -u); \
 		export DATE=$(shell date +%Y%m%d%H%M%S); \
 		docker compose up $(OPTIONS); \
 	fi

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -1,5 +1,5 @@
 ARG OPENHANDS_BUILD_VERSION=dev
-FROM node:24.8-trixie-slim AS frontend-builder
+FROM node:24.8-bookworm-slim AS frontend-builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ RUN npm ci
 COPY frontend ./
 RUN npm run build
 
-FROM python:3.13.7-slim-trixie AS base
+FROM python:3.13.7-slim-bookworm AS base
 FROM base AS backend-builder
 
 WORKDIR /app

--- a/containers/dev/compose.yml
+++ b/containers/dev/compose.yml
@@ -12,15 +12,14 @@ services:
       - SANDBOX_API_HOSTNAME=host.docker.internal
       - DOCKER_HOST_ADDR=host.docker.internal
       #
-      - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-ghcr.io/openhands/runtime:0.60-nikolaik}
-      - SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234}
+      #- SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-ghcr.io/openhands/runtime:0.60-nikolaik}
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
     ports:
-      - "3000:3000"
+      - "3001:3000"
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "host.docker.internal:192.168.0.144"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/user/1000/docker.sock:/var/run/docker.sock
       - ${WORKSPACE_BASE:-$PWD/workspace}:/opt/workspace_base
       # source code
       - ${OPENHANDS_WORKSPACE:-../../}:/app

--- a/containers/dev/dev.sh
+++ b/containers/dev/dev.sh
@@ -31,9 +31,35 @@ cd "$OPENHANDS_WORKSPACE/containers/dev/" || exit 1
 ##
 export BACKEND_HOST="0.0.0.0"
 #
-export SANDBOX_USER_ID=$(id -u)
-export WORKSPACE_BASE=${WORKSPACE_BASE:-$OPENHANDS_WORKSPACE/workspace}
+#export SANDBOX_USER_ID=$(id -u)
+#export WORKSPACE_BASE=${WORKSPACE_BASE:-$OPENHANDS_WORKSPACE/workspace}
 
-docker compose run --rm --service-ports "$@" dev
+#docker compose run --rm --service-ports "$@" dev
+#export SANDBOX_USER_ID=$(id -u)
+#export WORKSPACE_BASE=${WORKSPACE_BASE:-$OPENHANDS_WORKSPACE/workspace}
+export WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE
+export AGENT_ENABLE_PROMPT_EXTENSIONS=false
+export LOG_ALL_EVENTS=true
+export LLM_NATIVE_TOOL_CALLING=true
+export LLM_DISABLE_STOP_WORD=true
+export LLM_REASONING_EFFORT=high
+export WORKSPACE_BASE=/home/jesse/sandbox
+
+# --service-ports "$@"
+docker compose run --rm -p 3001:3000 -p 3003:3001 \
+  -e WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE \
+    -v $WORKSPACE_BASE:/opt/workspace_base \
+    -e AGENT_ENABLE_PROMPT_EXTENSIONS=false \
+    -e LOG_ALL_EVENTS=true \
+    -e LLM_NATIVE_TOOL_CALLING=true \
+    -e LLM_DISABLE_STOP_WORD=true \
+    -e LLM_REASONING_EFFORT=high \
+    -e FILE_STORE_PATH=/.openhands \
+    -e SANDBOX_ENABLE_GPU=true \
+    -e SANDBOX_CUDA_VISIBLE_DEVICES=0 \
+    -e DEBUG=true \
+    -v ~/.openhands:/.openhands \
+    -v /run/user/1000/docker.sock:/var/run/docker.sock \
+  dev
 
 ##

--- a/containers/dev_cuda/Dockerfile
+++ b/containers/dev_cuda/Dockerfile
@@ -1,0 +1,21 @@
+#FROM docker.openhands.dev/openhands/runtime:0.60-nikolaik
+FROM openhands-jesse
+RUN sudo apt update
+RUN sudo apt install -y libtbb-dev libssl-dev libcurl4-openssl-dev libaio1 \
+    libaio-dev libfmt-dev libgflags-dev zlib1g-dev patchelf cmake ccache
+RUN pip3 install packaging ninja
+RUN sudo apt install -y wget
+RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda-repo-debian12-12-8-local_12.8.1-570.124.06-1_amd64.deb
+RUN sudo dpkg -i cuda-repo-debian12-12-8-local_12.8.1-570.124.06-1_amd64.deb
+RUN sudo cp /var/cuda-repo-debian12-12-8-local/cuda-*-keyring.gpg /usr/share/keyrings/
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sudo apt-get update
+RUN sudo apt-get -y install cuda-toolkit-12-8
+RUN apt-get install -y cuda-drivers
+USER root
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["uvicorn", "openhands.server.listen:app", "--host", "0.0.0.0", "--port", "3000"]
+

--- a/containers/dev_cuda/build.sh
+++ b/containers/dev_cuda/build.sh
@@ -1,0 +1,1 @@
+docker build --progress=plain --no-cache -t open_hands_cuda_runtime .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,30 @@ services:
     build:
       context: ./
       dockerfile: ./containers/app/Dockerfile
-    image: openhands:latest
+      extra_hosts:
+        - "host.docker.internal:192.168.0.144"
+    image: openhands-jesse:latest
     container_name: openhands-app-${DATE:-}
     environment:
-      - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-docker.openhands.dev/openhands/runtime:0.60-nikolaik}
+      #- SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:open_hands_cuda_runtime}
+      #- SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-docker.openhands.dev/openhands/runtime:0.60-nikolaik}
       #- SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234} # enable this only if you want a specific non-root sandbox user but you will have to manually adjust permissions of ~/.openhands for this user
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
+      - DEBUG=true
     ports:
-      - "3000:3000"
+      - "3001:3000"
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "host.docker.internal:192.168.0.144"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 'all'
+              capabilities: [gpu]
+                #device_ids: ['0']
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/user/1000/docker.sock:/var/run/docker.sock
       - ~/.openhands:/.openhands
       - ${WORKSPACE_BASE:-$PWD/workspace}:/opt/workspace_base
     pull_policy: build

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -53,7 +53,7 @@ class SandboxConfig(BaseModel):
     rm_all_containers: bool = Field(default=False)
     api_key: str | None = Field(default=None)
     base_container_image: str | None = Field(
-        default='nikolaik/python-nodejs:python3.12-nodejs22'
+        default='nikolaik/python-nodejs:python3.12-nodejs22-bookworm'
     )
     runtime_container_image: str | None = Field(default=None)
     user_id: int = Field(default=os.getuid() if hasattr(os, 'getuid') else 1000)

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -495,19 +495,24 @@ class DockerRuntime(ActionExecutionClient):
         self.log('info', f'Starting server with command: {command}')
 
         if self.config.sandbox.enable_gpu:
+            self.log('info', f'sandbox enable_gpu is true')
             gpu_ids = self.config.sandbox.cuda_visible_devices
             if gpu_ids is None:
+                self.log('info', f'no gpu_ids')
                 device_requests = [
                     docker.types.DeviceRequest(capabilities=[['gpu']], count=-1)
                 ]
             else:
+                device_ids=[str(i) for i in gpu_ids.split(',')]
                 device_requests = [
                     docker.types.DeviceRequest(
                         capabilities=[['gpu']],
-                        device_ids=[str(i) for i in gpu_ids.split(',')],
+                        device_ids=device_ids,
                     )
                 ]
+                self.log('info', f'gpu device_ids: {device_ids}')
         else:
+            self.log('info', f'sandbox enable_gpu is false')
             device_requests = None
         try:
             if self.runtime_container_image is None:

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -45,6 +45,7 @@ def _generate_dockerfile(
     Returns:
     - str: The resulting Dockerfile content
     """
+    print(f'_generate_dockerfile base_image: {base_image}')
     env = Environment(
         loader=FileSystemLoader(
             searchpath=os.path.join(os.path.dirname(__file__), 'runtime_templates')
@@ -59,6 +60,7 @@ def _generate_dockerfile(
         extra_deps=extra_deps if extra_deps is not None else '',
         enable_browser=enable_browser,
     )
+    print(f'_generate_dockerfile dockerfile_content: {dockerfile_content}')
     return dockerfile_content
 
 
@@ -394,7 +396,7 @@ def _build_sandbox_image(
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--base_image', type=str, default='nikolaik/python-nodejs:python3.12-nodejs22'
+        '--base_image', type=str, default='nikolaik/python-nodejs:python3.12-nodejs22-bookworm'
     )
     parser.add_argument('--build_folder', type=str, default=None)
     parser.add_argument('--force_rebuild', action='store_true', default=False)

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -342,6 +342,22 @@ COPY --chown=openhands:openhands ./code/openhands /openhands/code/openhands
 RUN chmod a+rwx /openhands/code/openhands/__init__.py && \
     chown -R openhands:openhands /openhands/code
 
+# ===
+# cuda
+# ===
+RUN sudo apt update
+RUN sudo apt install -y libtbb-dev libssl-dev libcurl4-openssl-dev libaio1 \
+    libaio-dev libfmt-dev libgflags-dev zlib1g-dev patchelf cmake ccache
+RUN pip3 install packaging ninja
+RUN sudo apt install -y wget
+RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda-repo-debian12-12-8-local_12.8.1-570.124.06-1_amd64.deb
+RUN sudo dpkg -i cuda-repo-debian12-12-8-local_12.8.1-570.124.06-1_amd64.deb
+RUN sudo cp /var/cuda-repo-debian12-12-8-local/cuda-*-keyring.gpg /usr/share/keyrings/
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sudo apt-get update
+RUN sudo apt-get -y install cuda-toolkit-12-8
+RUN apt-get install -y cuda-drivers
+
 
 # ================================================================
 # END: Build from versioned image


### PR DESCRIPTION
@SmartManoj I *just* got this working successfully and completely. I just successfully built CUDA enabled unit tests for the llama.cpp project under Open Hands:

<img width="1512" height="897" alt="Image" src="https://github.com/user-attachments/assets/b5eaaec4-8a66-488a-8296-9f33a02de747" />



Key sticking points I had to overcome:
1. I'm running under rootless docker on ubuntu 24.04, so I removed `SANDBOX_USER_ID` and let the containers run as `root`. Otherwise my permissions would get messed up with fake UIDs.
1. rootless docker does not have `host-gateway`, so I hard coded it to my machine's local IP, which is `192.168.0.144`.
1. rootless docker's socket changes to `/run/user/1000/docker.sock` where `1000` is my UID.
1. I had to rebuild the runtime using debian bookworm because debian trixie comes with gcc 14 and CUDA 12.8.1 doesn't like it. This meant changing `nikolaik/python-nodejs:python3.12-nodejs22` to `nikolaik/python-nodejs:python3.12-nodejs22-bookworm` in `openhands/core/config/sandbox_config.py`.  I also added CUDA to the runtime by adding this to the `Dockerfile.j2`:

   **openhands/runtime/utils/runtime_templates/Dockerfile.j2**

   ```Dockerfile
   # ===
   # cuda
   # ===
   RUN sudo apt update
   RUN sudo apt install -y libtbb-dev libssl-dev libcurl4-openssl-dev libaio1 \
       libaio-dev libfmt-dev libgflags-dev zlib1g-dev patchelf cmake ccache
   RUN pip3 install packaging ninja
   RUN sudo apt install -y wget
   RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda-repo-debian12-12-8-local_12.8.1-570.124.06-1_amd64.deb
   RUN sudo dpkg -i cuda-repo-debian12-12-8-local_12.8.1-570.124.06-1_amd64.deb
   RUN sudo cp /var/cuda-repo-debian12-12-8-local/cuda-*-keyring.gpg /usr/share/keyrings/
   ENV DEBIAN_FRONTEND=noninteractive
   RUN sudo apt-get update
   RUN sudo apt-get -y install cuda-toolkit-12-8
   RUN apt-get install -y cuda-drivers
   ```

   Then I rebuilt the runtime locally using the dev workflow. This gives me a local container named `ghcr.io/openhands/runtime:oh_v0.60.0_llefkedr1hqq2801_zs1mkp9nnwhmnyxc`.
1. After I did all of that, I started it up using the following command ( note `--gpus all` ):

   ```bash
   docker run -it --rm \
       -p 3001:3000 \
       -e WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE \
       -v $WORKSPACE_BASE:/opt/workspace_base \
       -e AGENT_ENABLE_PROMPT_EXTENSIONS=false \
       -e LOG_ALL_EVENTS=true \
       -e LLM_NATIVE_TOOL_CALLING=true \
       -e LLM_DISABLE_STOP_WORD=true \
       -e LLM_REASONING_EFFORT=high \
       -e SANDBOX_ENABLE_GPU=true \
       -e SANDBOX_CUDA_VISIBLE_DEVICES=0 \
       -v ~/.openhands:/.openhands \
       -v /run/user/1000/docker.sock:/var/run/docker.sock \
       --add-host host.docker.internal:192.168.0.144 \
       -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/openhands/runtime:oh_v0.60.0_llefkedr1hqq2801_zs1mkp9nnwhmnyxc \
       --name openhands-app \
       --gpus all \
       docker.openhands.dev/openhands/openhands:0.60
   ```

   I probably could have continued using the dev workflow, but I had trouble tracking down all the instances of `SANDBOX_USER_ID` so this was an easier way to sidestep that issue.

